### PR TITLE
installation is now run from monorepo

### DIFF
--- a/src/deployer.sh
+++ b/src/deployer.sh
@@ -34,16 +34,16 @@ echo ${EXTERNAL_IP} > /code/build-${BUILD_NUMBER}/ip-address
 
 # These seds are required for older versions of Shopsys which was not prepared for automated installing (fixing user rights and allocating a pseudo TTY)
 gcloud compute ssh ${SERVICE_ACCOUNT_LOGIN}@${INSTANCE_NAME} \
-    --command='cd shopsys/project-base &&
+    --command='cd shopsys &&
         sed -i -r "s#www_data_uid: [0-9]+#www_data_uid: $(id -u)#" docker/conf/docker-compose.yml.dist &&
         sed -i -r "s#www_data_gid: [0-9]+#www_data_gid: $(id -g)#" docker/conf/docker-compose.yml.dist &&
-        sed -i -r "s#docker-compose exec php-fpm#docker-compose exec -T php-fpm#" ./scripts/install.sh &&
-        echo 1 | ./scripts/install.sh'
+        sed -i -r "s#docker-compose exec php-fpm#docker-compose exec -T php-fpm#" ./project-base/scripts/install.sh &&
+        echo 1 | ./project-base/scripts/install.sh'
 
 gcloud compute ssh ${SERVICE_ACCOUNT_LOGIN}@${INSTANCE_NAME} \
-    --command="cd shopsys/project-base &&
-        sed -i -r \"s#127\.0\.0\.1#${EXTERNAL_IP}#\" ./app/config/domains_urls.yml &&
+    --command="cd shopsys &&
+        sed -i -r \"s#127\.0\.0\.1#${EXTERNAL_IP}#\" ./project-base/app/config/domains_urls.yml &&
         docker-compose exec -T php-fpm php phing test-db-performance &&
-        sed -i -r \"s#database_name: shopsys#database_name: shopsys-test#g\" ./app/config/parameters.yml &&
+        sed -i -r \"s#database_name: shopsys#database_name: shopsys-test#g\" ./project-base/app/config/parameters.yml &&
         docker-compose exec -T php-fpm bin/console shopsys:environment:change prod &&
         docker-compose exec -T php-fpm php phing clean"


### PR DESCRIPTION
While the whole monorepo is cloned, the installation should be run from root directory, not project-base. 

Installation from the monorepo root use `composer.json` file with dependencies from `packages` folder, but installation from project-base folder use `composer.json` from project-base and all shopsys dependencies are downloaded from packagist in different version (for example when I try to test my-branch, dependencies are installed in 9.0.x-dev version from the latest monorepo split).